### PR TITLE
Next version

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 dist/
 coverage/
-example/build/
+.yarn/

--- a/.yarn/versions/f9f6f06f.yml
+++ b/.yarn/versions/f9f6f06f.yml
@@ -1,0 +1,2 @@
+releases:
+  react-cookienotice: patch

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ npm i --save react-cookienotice
 
 ```tsx
 import React from 'react'
-
 import CookieNotice from 'react-cookienotice'
 import 'react-cookienotice/dist/index.css'
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "npm-run-all": "^4.1.5",
     "postcss-normalize": "^10.0.1",
     "prettier": "^2.6.2",
+    "prettier-plugin-organize-imports": "^3.1.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",

--- a/src/components/button.test.tsx
+++ b/src/components/button.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
-import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-
+import { render } from '@testing-library/react'
+import React from 'react'
 import Button from './button'
 
 describe('Button', () => {

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
-
-import styles from '../styles.module.css'
-
 import clsx from '../helpers/classnames'
+import styles from '../styles.module.css'
 
 interface ButtonProps {
   onClick?: () => void

--- a/src/components/cookie-notice.stories.tsx
+++ b/src/components/cookie-notice.stories.tsx
@@ -1,6 +1,5 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { ComponentStory, ComponentMeta } from '@storybook/react'
-
 import CookieNotice from './cookie-notice'
 
 export default {

--- a/src/components/cookie-notice.test.tsx
+++ b/src/components/cookie-notice.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react'
-import { render, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
-
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import { getCookie, setCookie } from '../helpers/cookies'
 import CookieNotice from './cookie-notice'
-
-import { setCookie, getCookie } from '../helpers/cookies'
 
 jest.mock('../helpers/cookies', () => ({
   setCookie: jest.fn(),

--- a/src/components/cookie-notice.tsx
+++ b/src/components/cookie-notice.tsx
@@ -1,21 +1,18 @@
-import React, { useState, useCallback } from 'react'
-
-import styles from '../styles.module.css'
-
-import Text from './text'
-import Link from './link'
-import Button from './button'
-
-import { setCookie, getCookie } from '../helpers/cookies'
+import React, { useCallback, useState } from 'react'
 import clsx from '../helpers/classnames'
+import { getCookie, setCookie } from '../helpers/cookies'
 import { formatMessage } from '../intl/format'
+import styles from '../styles.module.css'
 import {
-  validateLabel,
-  validateLink,
   validateBoolean,
   validateCookieExpiration,
   validateCookieName,
+  validateLabel,
+  validateLink,
 } from '../validator'
+import Button from './button'
+import Link from './link'
+import Text from './text'
 
 export interface CookieNoticeProps {
   /**

--- a/src/components/link.test.tsx
+++ b/src/components/link.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
-import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-
+import { render } from '@testing-library/react'
+import React from 'react'
 import Link from './link'
 
 describe('Link', () => {

--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
-
-import styles from '../styles.module.css'
-
 import clsx from '../helpers/classnames'
+import styles from '../styles.module.css'
 
 interface LinkProps {
   to?: string

--- a/src/components/text.test.tsx
+++ b/src/components/text.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
-import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-
+import { render } from '@testing-library/react'
+import React from 'react'
 import Text from './text'
 
 describe('Text', () => {

--- a/src/helpers/cookies.test.ts
+++ b/src/helpers/cookies.test.ts
@@ -1,6 +1,5 @@
 import MockDate from 'mockdate'
-
-import { setCookie, getCookie } from './cookies'
+import { getCookie, setCookie } from './cookies'
 
 describe('cookies', () => {
   beforeEach(() => {

--- a/src/helpers/debug.test.ts
+++ b/src/helpers/debug.test.ts
@@ -1,4 +1,4 @@
-import { warn, err } from './debug'
+import { err } from './debug'
 
 describe('debug', () => {
   describe('in development', () => {
@@ -15,18 +15,6 @@ describe('debug', () => {
 
     afterEach(() => {
       process.env = originalEnv
-    })
-
-    it('should call console.warn', () => {
-      const mockedConsoleWarn = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {})
-
-      warn('message')
-
-      expect(mockedConsoleWarn).toHaveBeenCalledWith(
-        '[react-cookienotice] message',
-      )
     })
 
     it('should call console.error', () => {
@@ -56,16 +44,6 @@ describe('debug', () => {
 
     afterEach(() => {
       process.env = originalEnv
-    })
-
-    it('should not call console.warn', () => {
-      const mockedConsoleWarn = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {})
-
-      warn('message')
-
-      expect(mockedConsoleWarn).not.toHaveBeenCalled()
     })
 
     it('should not call console.error', () => {

--- a/src/helpers/debug.ts
+++ b/src/helpers/debug.ts
@@ -1,9 +1,3 @@
-export const warn = (message: string): void => {
-  if (process.env.NODE_ENV === 'development') {
-    console.warn(`[react-cookienotice] ${message}`)
-  }
-}
-
 export const err = (message: string): void => {
   if (process.env.NODE_ENV === 'development') {
     console.error(`[react-cookienotice] ${message}`)

--- a/src/intl/format.test.ts
+++ b/src/intl/format.test.ts
@@ -1,8 +1,6 @@
 import { err } from '../helpers/debug'
-
-import messages from './messages'
-
 import { formatMessage } from './format'
+import messages from './messages'
 
 jest.mock('../helpers/debug', () => ({
   err: jest.fn(),

--- a/src/intl/format.test.ts
+++ b/src/intl/format.test.ts
@@ -1,6 +1,12 @@
-import { formatMessage } from './format'
+import { err } from '../helpers/debug'
 
 import messages from './messages'
+
+import { formatMessage } from './format'
+
+jest.mock('../helpers/debug', () => ({
+  err: jest.fn(),
+}))
 
 describe('format', () => {
   beforeEach(() => {
@@ -33,14 +39,8 @@ describe('format', () => {
     })
 
     it('with invalid message', () => {
-      const mockedConsoleError = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
       expect(formatMessage('invalid')).toBe('invalid')
-      expect(mockedConsoleError).toHaveBeenCalledWith(
-        '[intl] no message found for id "invalid"',
-      )
+      expect(err).toHaveBeenCalledWith('no message found for id "invalid"')
     })
 
     it('with overriden message', () => {

--- a/src/intl/format.ts
+++ b/src/intl/format.ts
@@ -1,3 +1,5 @@
+import { err } from '../helpers/debug'
+
 import messages from './messages'
 
 const DEFAULT_LANGUAGE = 'en'
@@ -14,7 +16,7 @@ export const formatMessage = (id: string, override?: string): string => {
     : DEFAULT_LANGUAGE
 
   if (messages[usedLanguage][id] === undefined) {
-    console.error(`[intl] no message found for id "${id}"`)
+    err(`no message found for id "${id}"`)
     return id
   }
 

--- a/src/intl/format.ts
+++ b/src/intl/format.ts
@@ -1,5 +1,4 @@
 import { err } from '../helpers/debug'
-
 import messages from './messages'
 
 const DEFAULT_LANGUAGE = 'en'

--- a/src/validator/index.test.ts
+++ b/src/validator/index.test.ts
@@ -1,11 +1,10 @@
 import {
-  validateLabel,
-  validateLink,
   validateBoolean,
   validateCookieExpiration,
   validateCookieName,
+  validateLabel,
+  validateLink,
 } from '.'
-
 import { err } from '../helpers/debug'
 
 jest.mock('../helpers/debug', () => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -18683,6 +18683,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-organize-imports@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "prettier-plugin-organize-imports@npm:3.1.1"
+  peerDependencies:
+    "@volar/vue-typescript": ">=0.40.2"
+    prettier: ">=2.0"
+    typescript: ">=2.9"
+  peerDependenciesMeta:
+    "@volar/vue-typescript":
+      optional: true
+  checksum: a5776ddf70ba83990c5f97799a57e9844379226c25c5d3e89c072dce3615575aacc1da9c0870b86dcfd4df80df4194971538765f84a168cbb41d36de81740c30
+  languageName: node
+  linkType: hard
+
 "prettier@npm:>=2.2.1 <=2.3.0":
   version: 2.3.0
   resolution: "prettier@npm:2.3.0"
@@ -19185,6 +19199,7 @@ __metadata:
     npm-run-all: ^4.1.5
     postcss-normalize: ^10.0.1
     prettier: ^2.6.2
+    prettier-plugin-organize-imports: ^3.1.1
     react: ^18.1.0
     react-dom: ^18.1.0
     react-scripts: ^5.0.1


### PR DESCRIPTION
- remove useless code
- update `.prettierignore` file
- add `prettier-plugin-organize-imports` to devDeps
- format imports
- Bump v5.4.1
