### PR TITLE
fix(chore): resolve warning of css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -172,7 +172,7 @@
   > .react-cookienotice-services
   > .react-cookienotice-service {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .react-cookienotice-root


### PR DESCRIPTION
This issue with mixed support for the `start` value in `autoprefixer` is resolved with this merge request, which replaces `start` with `flex-start` for better compatibility.

```bash
(6:2456) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
./node_modules/react-cookienotice/dist/react-cookienotice.css.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[13].oneOf[10].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[13].oneOf[10].use[3]!./node_modules/react-cookienotice/dist/react-cookienotice.css
./node_modules/react-cookienotice/dist/react-cookienotice.css
```